### PR TITLE
Add support for _acl files in vhost.d

### DIFF
--- a/nginx-proxy/nginx.tmpl
+++ b/nginx-proxy/nginx.tmpl
@@ -35,6 +35,12 @@
 		proxy_pass {{ trim .Proto }}://{{ trim .Upstream }}/;
 	{{ end }}
 
+	{{ if (exists (printf "/etc/nginx/vhost.d/%s_acl" .Host)) }}
+		include {{ printf "/etc/nginx/vhost.d/%s_acl" .Host}};
+	{{ else if (exists "/etc/nginx/vhost.d/default_acl") }}
+		include /etc/nginx/vhost.d/default_acl;
+	{{ end }}
+
 	{{ if (exists (printf "/etc/nginx/htpasswd/%s" .Host)) }}
 		auth_basic	"Restricted {{ .Host }}";
 		auth_basic_user_file	{{ (printf "/etc/nginx/htpasswd/%s" .Host) }};


### PR DESCRIPTION
This adds support for files like `${domain}_acl` or `default_acl` in the `vhost.d` directory for whitelisting IPs from HTTP Auth.

Signed-off-by: Mriyam Tamuli <mbtamuli@gmail.com>