### PR TITLE
Update timeout parameters.

### DIFF
--- a/nginx-proxy/nginx.conf
+++ b/nginx-proxy/nginx.conf
@@ -33,6 +33,10 @@ http {
     proxy_buffers 16 16k;
     proxy_buffer_size 32k;
 
+    proxy_connect_timeout 300;
+    proxy_read_timeout 300;
+    proxy_send_timeout 300;
+
     include /version.conf;
     include /etc/nginx/conf.d/*.conf;
 }

--- a/nginx/conf/fastcgi_params
+++ b/nginx/conf/fastcgi_params
@@ -26,3 +26,7 @@ fastcgi_param  REDIRECT_STATUS    200;
 
 # To fix CGI application vulnerability - https://httpoxy.org
 fastcgi_param   HTTP_PROXY      "";
+
+fastcgi_connect_timeout 300;
+fastcgi_send_timeout 300;
+fastcgi_read_timeout 300;


### PR DESCRIPTION
Add the following parameters in their respective files.

**nginx-proxy/nginx.conf**
```
proxy_connect_timeout 300;
proxy_read_timeout 300;
proxy_send_timeout 300;
```

**nginx/conf/fastcgi_params**
```
fastcgi_connect_timeout 300;
fastcgi_send_timeout 300;
fastcgi_read_timeout 300;
```

tested with this PHP script with setting timeout to `200`, `250`, `280` and `350`
```php
sleep( x ); // x = time to sleep
echo "done";
```