### PR TITLE
Update and Fix errors in PHP docker image

### DIFF
--- a/php/7.4/Dockerfile
+++ b/php/7.4/Dockerfile
@@ -22,26 +22,26 @@ RUN set -ex; \
 		libxml2-dev \
 		libpng-dev \
 		libzip-dev \
-        libssl-dev \
+		libssl-dev \
 		unzip \
 		vim \
 		zip
 
 RUN pecl install imagick; \
-    pecl install memcached; \
-    pecl install mcrypt-1.0.3; \
+	pecl install memcached; \
+	pecl install mcrypt-1.0.3; \
 	pecl install redis; \
 	docker-php-ext-configure gd --enable-gd-native-ttf --with-freetype-dir=/usr/include/freetype2 --with-png-dir=/usr/include --with-jpeg-dir=/usr/include \
 	docker-php-ext-configure zip --with-libzip; \
-    docker-php-ext-install gd; \
+	docker-php-ext-install gd; \
 	PHP_OPENSSL=yes docker-php-ext-configure imap --with-kerberos --with-imap-ssl; \
 	echo "extension=memcached.so" >> /usr/local/etc/php/conf.d/memcached.ini; \
-    docker-php-ext-install imap; \
-    docker-php-ext-install mysqli; \
-    docker-php-ext-install opcache; \
-    docker-php-ext-install soap; \
-    docker-php-ext-install zip; \
-    docker-php-ext-install exif; \
+	docker-php-ext-install imap; \
+	docker-php-ext-install mysqli; \
+	docker-php-ext-install opcache; \
+	docker-php-ext-install soap; \
+	docker-php-ext-install zip; \
+	docker-php-ext-install exif; \
 	docker-php-ext-enable imagick mcrypt redis; \
 	docker-php-ext-install bcmath; \
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
@@ -86,8 +86,8 @@ ENV NR_PORT=/run/newrelic/newrelic.sock
 
 # Setup logs
 RUN mkdir -p /var/log/php; \
-    chown -R www-data: /var/log/php; \
-    rm /usr/local/etc/php-fpm.d/*;
+	chown -R www-data: /var/log/php; \
+	rm /usr/local/etc/php-fpm.d/*;
 COPY php.ini /usr/local/etc/php/php.ini
 COPY easyengine.conf /usr/local/etc/php-fpm.d/easyengine.conf
 

--- a/php/7.4/Dockerfile
+++ b/php/7.4/Dockerfile
@@ -75,7 +75,7 @@ RUN { \
 
 RUN echo "host postfix\ntls off\nfrom ee4@easyengine.io" > /etc/msmtprc
 
-RUN curl -L https://download.newrelic.com/php_agent/release/newrelic-php5-9.4.1.250-linux.tar.gz | tar -C /tmp -zx && \
+RUN curl -L https://download.newrelic.com/php_agent/release/newrelic-php5-9.8.0.259-linux.tar.gz | tar -C /tmp -zx && \
 export NR_INSTALL_USE_CP_NOT_LN=1 && \
 export NR_INSTALL_SILENT=1 && \
 /tmp/newrelic-php5-*/newrelic-install install && \

--- a/php/7.4/Dockerfile
+++ b/php/7.4/Dockerfile
@@ -31,8 +31,8 @@ RUN pecl install imagick; \
 	pecl install memcached; \
 	pecl install mcrypt-1.0.3; \
 	pecl install redis; \
-	docker-php-ext-configure gd --enable-gd-native-ttf --with-freetype-dir=/usr/include/freetype2 --with-png-dir=/usr/include --with-jpeg-dir=/usr/include \
-	docker-php-ext-configure zip --with-libzip; \
+	docker-php-ext-configure gd --with-freetype --with-jpeg; \
+	docker-php-ext-configure zip; \
 	docker-php-ext-install gd; \
 	PHP_OPENSSL=yes docker-php-ext-configure imap --with-kerberos --with-imap-ssl; \
 	echo "extension=memcached.so" >> /usr/local/etc/php/conf.d/memcached.ini; \
@@ -75,7 +75,7 @@ RUN { \
 
 RUN echo "host postfix\ntls off\nfrom ee4@easyengine.io" > /etc/msmtprc
 
-RUN curl -L https://download.newrelic.com/php_agent/release/newrelic-php5-9.8.0.259-linux.tar.gz | tar -C /tmp -zx && \
+RUN curl -L https://download.newrelic.com/php_agent/release/newrelic-php5-9.10.1.263-linux.tar.gz | tar -C /tmp -zx && \
 export NR_INSTALL_USE_CP_NOT_LN=1 && \
 export NR_INSTALL_SILENT=1 && \
 /tmp/newrelic-php5-*/newrelic-install install && \


### PR DESCRIPTION
**Updates:**
1. PHP-FPM to version 7.4.5.
2. NewRelic PHP agent version.

**Fixes:**
1. `configure: error: unrecognized options: --with-libzip`
    ref: https://github.com/laradock/laradock/issues/2453
    ref: https://github.com/php/php-src/blob/PHP-7.4/UPGRADING#L823-L825


2. `configure: WARNING: unrecognized options: --with-freetype-dir, --with-jpeg-dir, --with-png-dir
`
    ref: https://github.com/docker-library/php/issues/912
    ref: https://github.com/php/php-src/blob/PHP-7.4/UPGRADING#L755-L764