### PR TITLE
Update OpenResty docker image version

### DIFF
--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,4 +1,4 @@
-FROM openresty/openresty@sha256:6c93c32699d4b3438cfb6a37890128705c5dd39de08fbdc435dfcf3886227dd2
+FROM openresty/openresty@sha256:12bd5565639edec7f92cf04ca4bf635b0cba974130d182a71f8ab1fa79d59398
 LABEL org.label-schema.schema-version="1.0.0-rc1"
 LABEL org.label-schema.vendor="EasyEngine"
 LABEL org.label-schema.name="nginx"


### PR DESCRIPTION
Updates OpenResty version to `openresty/1.15.8.3` from `openresty/1.15.8.2`
ChangeLog: https://openresty.org/en/changelog-1015008.html

Signed-off-by: dhsathiya <devarshisathiya5@gmail.com>