### PR TITLE
Minor fixes

### DIFF
--- a/mariadb/Dockerfile
+++ b/mariadb/Dockerfile
@@ -1,4 +1,4 @@
-FROM mariadb:10.10@sha256:a98834606bea049d3094d0d90964eb749d9a10c46f60e58e67ca75a6a155c1ad
+FROM mariadb:10.8.2@sha256:490f01279be1452f12f497a592112cb960cf0500938dbf0ea3f0135cb6728d3d
 LABEL org.label-schema.schema-version="1.0.0"
 LABEL org.label-schema.vendor="EasyEngine"
 LABEL org.label-schema.name="db"

--- a/nginx-proxy/Dockerfile
+++ b/nginx-proxy/Dockerfile
@@ -3,7 +3,6 @@ LABEL org.label-schema.schema-version="1.0.0"
 LABEL org.label-schema.vendor="EasyEngine"
 LABEL org.label-schema.name="nginx-proxy"
 
-COPY docker-entrypoint.sh /app/
 COPY nginx.tmpl /app/
 COPY nginx.conf /etc/nginx/nginx.conf
 COPY version.conf /version.conf


### PR DESCRIPTION
Pin MariaDB to 10.8.2 due to Docker compatibility issue with docker version <`20.10.10` in higher MariaDB versions
