### PR TITLE
nginx.conf: Remove duplicated `daemon off;` from nginx.conf

### DIFF
--- a/nginx-proxy/nginx.conf
+++ b/nginx-proxy/nginx.conf
@@ -40,4 +40,3 @@ http {
     include /version.conf;
     include /etc/nginx/conf.d/*.conf;
 }
-daemon off;


### PR DESCRIPTION
As per https://github.com/nginx-proxy/nginx-proxy/commit/de4cb3d2b06171825e0df97414e1c3ac80e1cc73 this was set previously in the nginx.conf which we override manually in our dockerimage to copy our own custom config and since it was override there was no duplication. But now since this has been moved to the procfile it is getting set by default and and since we also have this in our config it is getting duplicated.

In order to use the image directly we can remove this from our configs 

Or if needed we can change the procfile as per our need