### PR TITLE
PHP 8.4 updates

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -106,6 +106,16 @@ updates:
       - mrrobot47
 
   - package-ecosystem: "docker"
+    directory: "/php/8.4"
+    ignore:
+      - dependency-name: "php"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
+    schedule:
+      interval: "weekly"
+    reviewers:
+      - mrrobot47
+
+  - package-ecosystem: "docker"
     directory: "/php/stable"
     ignore:
       - dependency-name: "php"

--- a/php/8.4/Dockerfile
+++ b/php/8.4/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.4.1-fpm
+FROM php:8.4.10-fpm
 
 LABEL maintainer="Riddhesh Sanghvi <riddhesh237@gmail.com>"
 LABEL org.label-schema.schema-version="1.0.0"
@@ -30,20 +30,6 @@ RUN set -ex; \
 		unzip \
 		vim \
 		zip
-
-# RUN curl -fsSLOJ https://pecl.php.net/get/mcrypt/stable \
-# 	&& tar -xf mcrypt-1.0.7.tgz
-# RUN cd mcrypt-1.0.7 \
-# 	&& phpize \
-# 	&& ./configure \
-# 	&& make \
-# 	&& curl -fsSLOJ https://github.com/php/pecl-encryption-mcrypt/commit/5b16bf1c97c1bbab400fc877285bf0919ae73256.diff \
-# 	&& git apply 5b16bf1c97c1bbab400fc877285bf0919ae73256.diff \
-# 	&& make test \
-# 	&& cp modules/*.so $(pecl config-get ext_dir) \
-# 	&& cd .. \
-# 	&& rm -rf mcrypt-1.0.7.tgz mcrypt-1.0.7
-# RUN echo extension="mcrypt.so" > /usr/local/etc/php/conf.d/php-ext-mcrypt.ini
 
 RUN pecl install imagick; \
 	pecl install memcached; \
@@ -133,14 +119,14 @@ ln -s /usr/local/etc/misc/msmtprc /etc/msmtprc && \
 chown www-data:www-data /usr/local/etc/misc/msmtprc && \
 chown www-data:www-data /etc/msmtprc
 
-# RUN latest_build=$(curl -s https://download.newrelic.com/php_agent/release/ | grep 'linux.tar.gz' | sed 's/.*"\(.*\)".*/\1/') && \
-# curl -L "https://download.newrelic.com$latest_build" | tar -C /tmp -zx && \
-# export NR_INSTALL_USE_CP_NOT_LN=1 && \
-# export NR_INSTALL_SILENT=1 && \
-# /tmp/newrelic-php5-*/newrelic-install install && \
-# rm -rf /tmp/newrelic-php5-* /tmp/nrinstall*
+RUN latest_build=$(curl -s https://download.newrelic.com/php_agent/release/ | grep 'linux.tar.gz' | sed 's/.*"\(.*\)".*/\1/') && \
+curl -L "https://download.newrelic.com$latest_build" | tar -C /tmp -zx && \
+export NR_INSTALL_USE_CP_NOT_LN=1 && \
+export NR_INSTALL_SILENT=1 && \
+/tmp/newrelic-php5-*/newrelic-install install && \
+rm -rf /tmp/newrelic-php5-* /tmp/nrinstall*
 
-# ENV NR_PORT=/run/newrelic/newrelic.sock
+ENV NR_PORT=/run/newrelic/newrelic.sock
 
 # Setup logs
 RUN mkdir -p /var/log/php; \
@@ -153,8 +139,8 @@ COPY expose_off.ini /usr/local/etc/php/conf.d/expose_off.ini
 COPY bashrc /root/.bashrc
 COPY bashrc /var/www/.bashrc
 COPY docker-entrypoint.sh /usr/local/bin/
-# COPY newrelic.ini /usr/local/etc/php/conf.d/newrelic.ini
-# COPY newrelic.ini /data/newrelic.ini
+COPY newrelic.ini /usr/local/etc/php/conf.d/newrelic.ini
+COPY newrelic.ini /data/newrelic.ini
 
 WORKDIR /var/www/htdocs
 RUN usermod -s /bin/bash www-data


### PR DESCRIPTION
This pull request includes updates to the `php/8.4` Docker setup, introducing dependency management in Dependabot, upgrading the PHP version, and enabling New Relic integration. Below are the key changes grouped by theme:

### Dependabot Configuration Updates:
* Added a new `package-ecosystem` entry for Docker in the `php/8.4` directory, with a weekly update schedule and restrictions on PHP version updates. (`.github/dependabot.yaml`, [.github/dependabot.yamlR108-R117](diffhunk://#diff-ee0c08340ace9ac3ce3c78e2377968bca2376b8bfd9a7a48d96515f5490a902cR108-R117))

### PHP Version Upgrade:
* Updated the base image in the `php/8.4/Dockerfile` from `php:8.4.1-fpm` to `php:8.4.10-fpm`, ensuring compatibility with the latest PHP features and fixes. (`php/8.4/Dockerfile`, [php/8.4/DockerfileL1-R1](diffhunk://#diff-adb522f4323b241a04a91b48c03751810b111e00691b8e3fa20a05333d924208L1-R1))

### Removal of Deprecated Code:
* Removed commented-out code related to the `mcrypt` extension, which is no longer maintained or required. (`php/8.4/Dockerfile`, [php/8.4/DockerfileL34-L47](diffhunk://#diff-adb522f4323b241a04a91b48c03751810b111e00691b8e3fa20a05333d924208L34-L47))

### New Relic Integration:
* Re-enabled the New Relic PHP agent installation and configuration, including the addition of `newrelic.ini` to the appropriate directories. (`php/8.4/Dockerfile`, [[1]](diffhunk://#diff-adb522f4323b241a04a91b48c03751810b111e00691b8e3fa20a05333d924208L136-R129) [[2]](diffhunk://#diff-adb522f4323b241a04a91b48c03751810b111e00691b8e3fa20a05333d924208L156-R143)