### PR TITLE
Install libc-client-dev from sury for debian trixie

### DIFF
--- a/php/8.1/Dockerfile
+++ b/php/8.1/Dockerfile
@@ -11,7 +11,6 @@ RUN set -ex; \
 		imagemagick \
 		less \
 		mariadb-client msmtp \
-		libc-client-dev \
 		libfreetype6-dev \
 		libjpeg-dev \
 		libjpeg62-turbo-dev \
@@ -30,6 +29,11 @@ RUN set -ex; \
 		unzip \
 		vim \
 		zip
+
+# Install libc-client-dev for imap from sury as not available for debian trixie
+RUN curl -fsSL https://packages.sury.org/php/README.txt | bash && \
+	apt-get update && \
+	apt-get install -y libc-client-dev
 
 RUN pecl install imagick; \
 	pecl install memcached; \

--- a/php/8.2/Dockerfile
+++ b/php/8.2/Dockerfile
@@ -11,7 +11,6 @@ RUN set -ex; \
 		imagemagick \
 		less \
 		mariadb-client msmtp \
-		libc-client-dev \
 		libfreetype6-dev \
 		libjpeg-dev \
 		libjpeg62-turbo-dev \
@@ -30,6 +29,11 @@ RUN set -ex; \
 		unzip \
 		vim \
 		zip
+
+# Install libc-client-dev for imap from sury as not available for debian trixie
+RUN curl -fsSL https://packages.sury.org/php/README.txt | bash && \
+	apt-get update && \
+	apt-get install -y libc-client-dev
 
 RUN pecl install imagick; \
 	pecl install memcached; \

--- a/php/8.3/Dockerfile
+++ b/php/8.3/Dockerfile
@@ -11,7 +11,6 @@ RUN set -ex; \
 		imagemagick \
 		less \
 		mariadb-client msmtp \
-		libc-client-dev \
 		libfreetype6-dev \
 		libjpeg-dev \
 		libjpeg62-turbo-dev \
@@ -30,6 +29,11 @@ RUN set -ex; \
 		unzip \
 		vim \
 		zip
+
+# Install libc-client-dev for imap from sury as not available for debian trixie
+RUN curl -fsSL https://packages.sury.org/php/README.txt | bash && \
+	apt-get update && \
+	apt-get install -y libc-client-dev
 
 # RUN pecl install imagick; \ # This is not working with PHP 8.3
 RUN pecl install memcached; \

--- a/php/8.4/Dockerfile
+++ b/php/8.4/Dockerfile
@@ -11,7 +11,6 @@ RUN set -ex; \
 		imagemagick \
 		less \
 		mariadb-client msmtp \
-		libc-client-dev \
 		libfreetype6-dev \
 		libjpeg-dev \
 		libjpeg62-turbo-dev \
@@ -30,6 +29,11 @@ RUN set -ex; \
 		unzip \
 		vim \
 		zip
+
+# Install libc-client-dev for imap from sury as not available for debian trixie
+RUN curl -fsSL https://packages.sury.org/php/README.txt | bash && \
+	apt-get update && \
+	apt-get install -y libc-client-dev
 
 RUN pecl install imagick; \
 	pecl install memcached; \


### PR DESCRIPTION
This pull request updates the installation process for the `libc-client-dev` package in the PHP Dockerfiles for versions 8.1, 8.2, 8.3, and 8.4. The main change is to switch from installing `libc-client-dev` directly via the default Debian repositories to installing it from the Sury PHP repository, which is necessary because the package is not available in Debian Trixie.

Dependency installation updates:

* Removed direct installation of `libc-client-dev` from the default package list in `php/8.1/Dockerfile`, `php/8.2/Dockerfile`, `php/8.3/Dockerfile`, and `php/8.4/Dockerfile`. [[1]](diffhunk://#diff-5abfe3e4f1a835f4ddcc5d9ebf822c11480c5efa53de51dfddf86d88627dbaf6L14) [[2]](diffhunk://#diff-0547785eeb2dd14068ba9a684fa576d1e5932e271252e7a7265e11b8e9170c3bL14) [[3]](diffhunk://#diff-35d65cc740ba6324d853e810e7bd08d0cd1dd505b770224f7639194e01c58d53L14) [[4]](diffhunk://#diff-adb522f4323b241a04a91b48c03751810b111e00691b8e3fa20a05333d924208L14)
* Added a new step in each Dockerfile to install `libc-client-dev` from the Sury PHP repository using `curl` and `apt-get`, ensuring compatibility with Debian Trixie. [[1]](diffhunk://#diff-5abfe3e4f1a835f4ddcc5d9ebf822c11480c5efa53de51dfddf86d88627dbaf6R33-R37) [[2]](diffhunk://#diff-0547785eeb2dd14068ba9a684fa576d1e5932e271252e7a7265e11b8e9170c3bR33-R37) [[3]](diffhunk://#diff-35d65cc740ba6324d853e810e7bd08d0cd1dd505b770224f7639194e01c58d53R33-R37) [[4]](diffhunk://#diff-adb522f4323b241a04a91b48c03751810b111e00691b8e3fa20a05333d924208R33-R37)