### PR TITLE
Add default HTML page for unconfigured domains

### DIFF
--- a/nginx-proxy/Dockerfile
+++ b/nginx-proxy/Dockerfile
@@ -6,6 +6,7 @@ LABEL org.label-schema.name="nginx-proxy"
 COPY nginx.tmpl /app/
 COPY nginx.conf /etc/nginx/nginx.conf
 COPY version.conf /version.conf
+COPY default.html /etc/nginx/html/default.html
 
 RUN apt-get update \
     && apt-get install --no-install-recommends apache2-utils -y && rm -rf /var/lib/apt/lists/*

--- a/nginx-proxy/default.html
+++ b/nginx-proxy/default.html
@@ -1,14 +1,15 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <title>Site Not Configured</title>
-    <style>
-        body { font-family: Arial, sans-serif; background: #f8f8f8; color: #333; text-align: center; padding-top: 10vh; }
-        h1 { color: #c00; }
-    </style>
+	<title>Site Not Configured</title>
+	<meta name="robots" content="noindex, nofollow, nosnippet, noarchive, noimageindex, notranslate">
+	<style>
+		body { font-family: Arial, sans-serif; background: #f8f8f8; color: #333; text-align: center; padding-top: 10vh; }
+		h1 { color: #c00; }
+	</style>
 </head>
 <body>
-    <h1>This domain is either disabled or not configured on this server.</h1>
-    <p>Please contact the administrator or check your domain settings.</p>
+	<h1>This domain is either disabled or not configured on this server.</h1>
+	<p>Please contact the administrator or check your domain settings.</p>
 </body>
 </html>

--- a/nginx-proxy/default.html
+++ b/nginx-proxy/default.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Site Not Configured</title>
+    <style>
+        body { font-family: Arial, sans-serif; background: #f8f8f8; color: #333; text-align: center; padding-top: 10vh; }
+        h1 { color: #c00; }
+    </style>
+</head>
+<body>
+    <h1>This domain is either disabled or not configured on this server.</h1>
+    <p>Please contact the administrator or check your domain settings.</p>
+</body>
+</html>

--- a/nginx-proxy/nginx.tmpl
+++ b/nginx-proxy/nginx.tmpl
@@ -190,8 +190,21 @@ server {
 	{{ end }}
 
 	root /etc/nginx/html;
+	
+	# Custom error page for 503
+	error_page 503 /default.html;
+	
 	location / {
-		try_files /default.html =404;
+		return 503;
+	}
+	
+	# Serve the error page without redirect
+	location = /default.html {
+		root /etc/nginx/html;
+		internal;
+		add_header Cache-Control "no-cache, no-store, must-revalidate" always;
+		add_header Pragma "no-cache" always;
+		add_header Expires "0" always;
 	}
 }
 
@@ -206,8 +219,21 @@ server {
 	{{ end }}
 
 	root /etc/nginx/html;
+	
+	# Custom error page for 503
+	error_page 503 /default.html;
+	
 	location / {
-		try_files /default.html =404;
+		return 503;
+	}
+	
+	# Serve the error page without redirect
+	location = /default.html {
+		root /etc/nginx/html;
+		internal;
+		add_header Cache-Control "no-cache, no-store, must-revalidate" always;
+		add_header Pragma "no-cache" always;
+		add_header Expires "0" always;
 	}
 
 	ssl_session_tickets off;

--- a/nginx-proxy/nginx.tmpl
+++ b/nginx-proxy/nginx.tmpl
@@ -184,23 +184,31 @@ server {
 {{ $enable_ipv6 := eq (or ($.Env.ENABLE_IPV6) "") "true" }}
 server {
 	server_name _; # This is just an invalid value which will never trigger on a real hostname.
-	listen 80;
+	listen 80 default_server;
 	{{ if $enable_ipv6 }}
-	listen [::]:80;
+	listen [::]:80 default_server;
 	{{ end }}
-	return 503;
+
+	root /etc/nginx/html;
+	location / {
+		try_files /default.html =404;
+	}
 }
 
 {{ if (and (exists "/etc/nginx/certs/default.crt") (exists "/etc/nginx/certs/default.key")) }}
 server {
 	server_name _; # This is just an invalid value which will never trigger on a real hostname.
-	listen 443 ssl;
+	listen 443 ssl default_server;
 	http2 on;
 	{{ if $enable_ipv6 }}
-	listen [::]:443 ssl;
+	listen [::]:443 ssl default_server;
 	http2 on;
 	{{ end }}
-	return 503;
+
+	root /etc/nginx/html;
+	location / {
+		try_files /default.html =404;
+	}
 
 	ssl_session_tickets off;
 	ssl_certificate /etc/nginx/certs/default.crt;


### PR DESCRIPTION
This pull request updates the default server response for the nginx-proxy image to provide a more user-friendly error page when a domain is not configured, instead of returning a generic 503 error. The changes ensure that requests to unconfigured domains serve a custom HTML page with a clear message.

**Default error page improvements:**

* Added a new `default.html` file containing a styled message indicating the domain is not configured or disabled. (`nginx-proxy/default.html`)
* Updated the `nginx.tmpl` template to serve `default.html` for requests to unconfigured domains, replacing the previous `return 503` directive. (`nginx-proxy/nginx.tmpl`)
* Changed default server `listen` directives to use `default_server` for both HTTP and HTTPS, ensuring the default configuration is properly applied. (`nginx-proxy/nginx.tmpl`)

**Docker image adjustments:**

* Modified the `Dockerfile` to copy the new `default.html` into the appropriate nginx HTML directory. (`nginx-proxy/Dockerfile`)