### PR TITLE
feat(nginx-proxy): Add SSL_STAPLING env var to control OCSP stapling

### DIFF
--- a/nginx-proxy/README.md
+++ b/nginx-proxy/README.md
@@ -139,6 +139,7 @@ deny all;
 | `VIRTUAL_PROTO` | Protocol (`http`, `https`, `uwsgi`, `fastcgi`) | `http` |
 | `HTTPS_METHOD` | `redirect`, `noredirect`, `nohttps` | `redirect` |
 | `SSL_POLICY` | SSL/TLS policy | `Mozilla-Modern` |
+| `SSL_STAPLING` | Enable OCSP stapling (`on` or `off`) | `on` |
 | `HSTS` | HSTS header value | `max-age=31536000` |
 | `CERT_NAME` | Custom certificate name | auto-detected |
 | `NETWORK_ACCESS` | `external` or `internal` | `external` |

--- a/nginx-proxy/nginx.tmpl
+++ b/nginx-proxy/nginx.tmpl
@@ -358,6 +358,9 @@ server {
 {{/* Get the HSTS defined by containers w/ the same vhost, falling back to "max-age=31536000" */}}
 {{ $hsts := or (first (groupByKeys $containers "Env.HSTS")) "max-age=31536000" }}
 
+{{/* Get the SSL_STAPLING defined by containers w/ the same vhost, falling back to "on" */}}
+{{ $ssl_stapling := or (first (groupByKeys $containers "Env.SSL_STAPLING")) "on" }}
+
 {{/* Get the VIRTUAL_ROOT By containers w/ use fastcgi root */}}
 {{ $vhost_root := or (first (groupByKeys $containers "Env.VIRTUAL_ROOT")) "/var/www/public" }}
 
@@ -445,7 +448,7 @@ server {
 	ssl_dhparam {{ printf "/etc/nginx/certs/%s.dhparam.pem" $cert }};
 	{{ end }}
 
-	{{ if (exists (printf "/etc/nginx/certs/%s.chain.pem" $cert)) }}
+	{{ if (and (eq $ssl_stapling "on") (exists (printf "/etc/nginx/certs/%s.chain.pem" $cert))) }}
 	ssl_stapling on;
 	ssl_stapling_verify on;
 	ssl_trusted_certificate {{ printf "/etc/nginx/certs/%s.chain.pem" $cert }};


### PR DESCRIPTION
## Summary

Add `SSL_STAPLING` environment variable to allow disabling OCSP stapling for certificates without OCSP responder URLs.

## Problem

Nginx logs warnings for certificates that don't have OCSP responder URLs:
```
nginx: [warn] "ssl_stapling" ignored, no OCSP responder URL in the certificate
```

This is common with self-signed certificates or certificates from CAs that don't provide OCSP.

## Solution

Add `SSL_STAPLING` environment variable (default: `on`) that can be set to `off` to disable OCSP stapling.

### Usage

```yaml
environment:
  - SSL_STAPLING=off
```

## Changes

- **nginx.tmpl**: Added `SSL_STAPLING` env var support with conditional check before enabling ssl_stapling
- **README.md**: Documented the new environment variable

---

> **Note**: We also investigated fixing the `nginx: [warn] protocol options redefined for 0.0.0.0:443` warning related to `http2 on;` directives. After testing multiple approaches (global http2, per-server-block http2, removing http2 from non-default blocks), we determined this is **expected nginx 1.25.1+ behavior** for multi-vhost SNI setups and cannot be fixed with template changes. The warning is benign and does not affect functionality.