### PR TITLE
feat(nginx-proxy): Implement ssl_reject_handshake for missing certificates

### DIFF
--- a/nginx-proxy/README.md
+++ b/nginx-proxy/README.md
@@ -130,6 +130,28 @@ deny all;
 
 ---
 
+## SSL Certificate Handling
+
+### Certificate Lookup
+
+The proxy automatically detects SSL certificates from `/etc/nginx/certs/`:
+
+```bash
+/etc/nginx/certs/example.com.crt
+/etc/nginx/certs/example.com.key
+```
+
+### Fallback Certificate Behavior
+
+When a vhost is accessed via HTTPS but no matching certificate is found:
+
+1. **If default certificate exists:** Uses `/etc/nginx/certs/default.crt` and returns 503
+2. **If no default certificate:** Rejects the SSL/TLS handshake
+
+This prevents certificate warning dialogs in browsers and improves security by not exposing invalid certificates.
+
+---
+
 ## Environment Variables
 
 | Variable | Description | Default |

--- a/nginx-proxy/nginx.tmpl
+++ b/nginx-proxy/nginx.tmpl
@@ -554,7 +554,7 @@ server {
 	{{ end }}
 }
 
-{{ if (and (not $is_https) (exists "/etc/nginx/certs/default.crt") (exists "/etc/nginx/certs/default.key")) }}
+{{ if (and (not $is_https) (ne $https_method "nohttps")) }}
 server {
 	server_name {{ $host }};
 	listen 443 ssl {{ $default_server }};
@@ -563,10 +563,17 @@ server {
 	listen [::]:443 ssl {{ $default_server }};
 	http2 on;
 	{{ end }}
-	return 500;
 
+	{{ if (and (exists "/etc/nginx/certs/default.crt") (exists "/etc/nginx/certs/default.key")) }}
+	# Use default certificate as fallback
 	ssl_certificate /etc/nginx/certs/default.crt;
 	ssl_certificate_key /etc/nginx/certs/default.key;
+	{{ else }}
+	# No valid certificate for this vhost nor default certificate found, so reject SSL handshake
+	ssl_reject_handshake on;
+	{{ end }}
+
+	return 503;
 }
 {{ end }}
 


### PR DESCRIPTION
## Summary

Implements `ssl_reject_handshake` directive for vhosts without valid SSL certificates, matching upstream jwilder/nginx-proxy behavior.

## Problem

When a vhost is accessed via HTTPS but has no valid certificate, the current behavior:
- Serves a 500 error with default certificate
- Shows certificate warning dialogs in browsers
- Exposes the default certificate unnecessarily

## Solution

Updated fallback HTTPS server block to:
1. **If default certificate exists:** Use it and return 503 (service unavailable)
2. **If no default certificate:** Reject the SSL/TLS handshake with `ssl_reject_handshake on;`

## Benefits

- ✅ Prevents browser certificate warnings
- ✅ More secure - doesn't expose invalid/default certificates  
- ✅ Cleaner failure mode for unknown hosts
- ✅ Matches nginx-proxy upstream behavior

## Changes

- **nginx.tmpl**: Updated fallback HTTPS server block with ssl_reject_handshake logic
- **README.md**: Added SSL Certificate Handling section documenting the behavior

## Testing

Test scenarios:
- ✅ Vhost with valid cert → Works normally
- ✅ Vhost without cert + default cert exists → Returns 503 with default cert
- ✅ Vhost without cert + no default cert → Rejects TLS handshake
