### PR TITLE
chore(deps): bump php from 8.5.0-fpm to 8.5.7-fpm in /php/8.5

### DIFF
--- a/php/8.5/Dockerfile
+++ b/php/8.5/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.5.0-fpm
+FROM php:8.5.7-fpm
 
 LABEL maintainer="Riddhesh Sanghvi <riddhesh237@gmail.com>"
 LABEL org.label-schema.schema-version="1.0.0"


### PR DESCRIPTION
Bumps `php` from `8.5.0-fpm` to `8.5.7-fpm` in `/php/8.5`.

---

**Release notes**

Sourced from [php's releases](https://hub.docker.com/_/php/tags?name=8.5).

- `8.5.7-fpm` — released 2026-06-05

---

This PR follows the same pattern as the Dependabot bumps for `php/8.3` and `php/8.4`.