### PR TITLE
chore(deps): bump openresty from 1.27.1.1-buster to 1.29.2.5-bookworm in /nginx

### DIFF
--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,4 +1,4 @@
-FROM openresty/openresty:1.27.1.1-buster
+FROM openresty/openresty:1.29.2.5-bookworm
 LABEL org.label-schema.schema-version="1.0.0"
 LABEL org.label-schema.vendor="EasyEngine"
 LABEL org.label-schema.name="nginx"


### PR DESCRIPTION
Bumps `openresty/openresty` from `1.27.1.1-buster` to `1.29.2.5-bookworm` in `/nginx`.

## Changes

- **OpenResty version:** `1.27.1.1` → `1.29.2.5`
- **Base OS:** `buster` (Debian 10, EOL) → `bookworm` (Debian 12)

## Notes

Debian Buster reached end-of-life in June 2024 and OpenResty dropped `buster`-based builds after `1.25.3.2`. The `1.27.x` and later series are only available on `bullseye`/`bookworm`/`alpine`. Migrating to `bookworm` keeps us on a supported base image going forward.

The Nginx Dockerfile contains no buster-specific package installs, so this is a clean drop-in replacement.