### PR TITLE
chore(deps): bump alpine from 3.23.3 to 3.23.4 in /newrelic-daemon

### DIFF
--- a/newrelic-daemon/Dockerfile
+++ b/newrelic-daemon/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.23.3
+FROM alpine:3.23.4
 
 LABEL maintainer="Riddhesh Sanghvi <riddhesh237@gmail.com>"
 LABEL org.label-schema.schema-version="1.0.0"


### PR DESCRIPTION
Bumps `alpine` from `3.23.3` to `3.23.4` in `/newrelic-daemon`.