### PR TITLE
chore(deps): bump jwilder/nginx-proxy from 1.10.1 to 1.11.0 in /nginx-proxy

### DIFF
--- a/nginx-proxy/Dockerfile
+++ b/nginx-proxy/Dockerfile
@@ -1,4 +1,4 @@
-FROM jwilder/nginx-proxy:1.10.1
+FROM jwilder/nginx-proxy:1.11.0
 LABEL org.label-schema.schema-version="1.0.0"
 LABEL org.label-schema.vendor="EasyEngine"
 LABEL org.label-schema.name="nginx-proxy"


### PR DESCRIPTION
Bumps `jwilder/nginx-proxy` from `1.10.1` to `1.11.0` in `/nginx-proxy`.