### PR TITLE
chore(deps): bump redis from 8.6.2 to 8.6.4 in /redis

### DIFF
--- a/redis/Dockerfile
+++ b/redis/Dockerfile
@@ -1,4 +1,4 @@
-FROM redis:8.6.2
+FROM redis:8.6.4
 
 LABEL org.label-schema.schema-version="1.0.0"
 LABEL org.label-schema.vendor="EasyEngine"


### PR DESCRIPTION
Bumps `redis` from `8.6.2` to `8.6.4` in `/redis`.