### PR TITLE
fix(mariadb): disable binary logs by default

### DIFF
--- a/mariadb/ee.cnf
+++ b/mariadb/ee.cnf
@@ -1,8 +1,1 @@
 [mysqld]
-log_bin                 = /var/log/mysql/mariadb-bin
-log_bin_index           = /var/log/mysql/mariadb-bin.index
-binlog_format           = statement
-# not fab for performance, but safer
-#sync_binlog            = 1
-expire_logs_days        = 10
-max_binlog_size         = 100M


### PR DESCRIPTION
## Summary

- Disable MariaDB binary logging by default in the EasyEngine MariaDB image.
- Remove the default `log_bin`, `log_bin_index`, `binlog_format`, `expire_logs_days`, and `max_binlog_size` settings from `mariadb/ee.cnf`.
- Keep the `[mysqld]` section so the config file remains valid.

## Why

EasyEngine does not configure or manage MariaDB replication for the global DB. Enabling binary logs by default causes persisted `mariadb-bin.*` files to grow without a practical total disk cap.

`max_binlog_size` only rotates individual files, and `expire_logs_days` only purges by age during specific server events. High-write installs can still fill disk.

## Notes

`skip-log-bin` is intentionally not added. Removing EasyEngine's default `log_bin` keeps binlogging off by default without overriding users who deliberately enable binlogs elsewhere.
